### PR TITLE
Adds tentative ask_updates() method to standard, plus an opinionated cleanup + code-samples in standard doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is an effort to standardize the interface of the **generators** 
 
   A generator is an object that recommends points to be evaluated in an optimization. It can also receive data (evaluations from past or on-going optimization), which helps it make more informed recommendations.
 
-  *Note:* The generator does **not** orchestrate the overall optimization (e.g. dispatch evaluations, etc.). As such, it is distinct from `libEnsemble`'s `gen_f` function.
+  *Note:* The generator does **not** orchestrate the overall optimization (e.g. dispatch evaluations, etc.). As such, it is distinct from `libEnsemble`'s `gen_f` function, and is not itself "workflow" software.
 
   *Examples:
     - `Xopt`: [here](https://github.com/ChristopherMayes/Xopt/blob/main/xopt/generators/scipy/neldermead.py#L64) is the generator for the Nelder-Mead method. All Xopt generators implement the methods `generate` (i.e. make recommendations) and `add_data` (i.e. receive data).
@@ -22,24 +22,70 @@ This repository is an effort to standardize the interface of the **generators** 
 
 Each type of generator (e.g., Nelder-Nead, different flavors of GA, BO, etc.) will be a Python class that defines the following methods:
 
-- **Constructor:**
+- `__init__(*args, **kwargs)`:
 
   The constructor will include variable positional and keyword arguments to
   accommodate the different options that each type of generator has.
 
-- `ask(num_points: Optional[int] = None) -> List[Dict])`:
+- `ask(num_points: Optional[int] = None) -> List[Dict]`:
 
-  Returns set of points in the input space, to be evaluated next. (Each element of the list is a separate point. Keys of the dictionary correspond to the name of each input variable.)
+  Returns a set of points in the input space to be evaluated next. Each element of the list is a separate point.
+  Keys of the dictionary correspond to the name of each input variable.
 
-  - When `num_points` is not passed: the generator decides how many points to return.
+  - Points are represented as dictionaries. Each dictionary can contain whichever keys are relevant to that generator, but each dictionary in a set should have the same keys:
+
+  ```python
+  >>> generator.ask(2)
+  [{"x": 3, "y": 4}, {"x": 1, "y": 2}]
+  ```
+
+  - When `num_points` is not passed, the generator decides how many points to return.
     Different generators will return different number of points, by default. For instance, the simplex would return 1 or 3 points. A genetic algorithm could return the whole population. Batched Bayesian optimization would return the batch size (i.e., number of points that can be processed in parallel), which would be specified in the constructor.
 
-  - When it is passed: the generator should return exactly this number of points, or raise a error (if it is unable to).
-    *Note:* If the user is flexible about the number of points, it should simply not pass `num_points`.
+  - When it is passed: the generator should return exactly this number of points, or raise ``ValueError`` if it is unable to. If the user is flexible about the number of points, it should simply not pass `num_points`.
 
-  *TBD: Which (array) format for the returned data?*
+  ```python
+  >>> generator.ask(100)  # too many points
+  ValueError
+  ```
 
+  ```python
+  >>> generator.ask()
+  [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 3, "y": 3}]
+  ```
 
-- `tell( points: List[Dict] )`:
+- `tell(points: List[Dict])`:
 
-  Feeds data (past evaluations) to the generator. (Each element of the list is a separate point. Keys of the dictionary correspond to the name of each input and output variable.)
+  Feeds data (past/complete evaluations) to the generator.
+
+  - Evaluation dictionaries must resemble dictionaries from `ask()`, with some update:
+
+  ```python
+  >>> point = generator.ask(1)
+  >>> point
+  [{"x": 1, "y": 1}]
+  >>> point["f"] = objective(point)
+  >>> point
+  [{"x": 1, "y": 1, "f": 2}]
+  >>> generator.tell(point)
+
+- **OPTIONAL**: `ask_updates() -> List[Dict]`
+
+  Returns a set of previously returned points that presumably contain some adjustments. For optimization algorithms, these may be points that have been identified as minima.
+  Other algorithms may want to cancel or disregard previous points.
+
+  - Any generator implementing this method must include ``"id"`` as a key to distinguish each point, with corresponding values being unique:
+
+  ```python
+  >>> point = generator.ask(1)
+  >>> point
+  [{"x": 1, "y": 1, "id": 1, "is_minima": False}]
+  >>> point["f"] = objective(point)
+  >>> point
+  [{"x": 1, "y": 1, "f": 2, "id": 1, "is_minima": False}]
+  >>> generator.tell(point)
+  >>> generator.ask_updates()
+  [{"x": 1, "y": 1, "f": 2, "id": 1, "is_minima": True}]
+  ```
+
+  - If no updates are available, return an empty list.

--- a/generator.py
+++ b/generator.py
@@ -46,6 +46,17 @@ class Generator(ABC):
             [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 3, "y": 3}]
         """
 
+    def ask_updates(self) -> List[dict]:
+        """
+        Request any adjustments to previous points.
+
+        .. code-block:: python
+
+            >>> points = my_generator.ask_updates()
+            >>> print(points)
+            [{"x": 1, "y": 1, "id": 1, "cancel": True}]
+        """
+
     def tell(self, results: List[dict]) -> None:
         """
         Send the results of evaluations to the generator.


### PR DESCRIPTION
Some thoughts:
- unique IDs may be a good part of the standard _at least_ for `ask_updates()`, but may also be useful for `.ask()` to generally keep track of points.
- I don't think `ask_updates()` needs an input `num_points` parameter. The number of possible updates I'd think is always substantially less than the number of possible points to generate?
- It's potentially asymmetrical that asking for updates that don't exist _doesnt_ error, where asking for points that don't exist _does_ error. I'm not sure what the solution is, or if this is even worth worrying about.
- Perhaps this data could be included in the output of `.ask()` instead