### PR TITLE
Update example links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ This repository is an effort to standardize the interface of the **generators** 
 
   *Note:* The generator does **not** orchestrate the overall optimization (e.g. dispatch evaluations, etc.). As such, it is distinct from `libEnsemble`'s `gen_f` function, and is not itself "workflow" software.
 
-  *Examples:*
-    - `Xopt`: [here](https://github.com/ChristopherMayes/Xopt/blob/main/xopt/generators/sequential/neldermead.py#L64) is the generator for the Nelder-Mead method. All Xopt generators implement the methods `generate` (i.e. make recommendations) and `add_data` (i.e. receive data).
-    - `optimas`: [here](https://github.com/optimas-org/optimas/blob/main/optimas/generators/base.py#L27) is the base class for all generators. It implements the methods `suggest` (i.e. make recommendations) and `ingest` (i.e. receive data).
-
 - **Variables, Objectives, Constraints (VOCS):**
 
   A `VOCS` is an object that specifies the names and types of components of the optimization problem that will be used by the generator. Each generator will validate that it can handle the specified set of variables, objectives, constraints, etc.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is an effort to standardize the interface of the **generators** 
 
 *Examples:*
 > Using `libEnsemble` generators in `Optimas`:
-> [APOSMM generator][ex-aposmm-optimas]
+> APOSMM [NLopt][ex-aposmm-nlopt-optimas] - [IBCDFO][ex-aposmm-ibcdfo-optimas]
 >
 > Using `Xopt` generators in `Optimas`:
 > [Multiple Examples][ex-xopt-optimas]
@@ -165,7 +165,8 @@ Each generator has a boolean class attribtue `returns_id`, defined in the base c
   Indicates whether this is an `_id` producing generator.
 
 
-[ex-aposmm-optimas]: https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py
+[ex-aposmm-nlopt-optimas]: https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_nlopt/run_example.py
+[ex-aposmm-ibcdfo-optimas]: https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_ibcdfo/run_example.py
 [ex-xopt-optimas]: https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py
 [ex-xopt-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py
 [ex-xopt-sim-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI_xopt_sim.py

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository is an effort to standardize the interface of the **generators** 
 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
-*Example: [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/151)*
+*Examples:*  
+> [using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)  
+> [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/151)
 
 # Definitions
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is an effort to standardize the interface of the **generators** 
 >
 > [Using `Xopt` generators in `Optimas`][ex-xopt-optimas]
 >
-> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe]
+> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe] [with xopt-style sim](ex-xopt-sim-libe)
 >
 > [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`][ex-optimas-libe]
 
@@ -165,6 +165,7 @@ Each generator has a boolean class attribtue `returns_id`, defined in the base c
 [ex-aposmm-optimas]: https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py
 [ex-xopt-optimas]: https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py
 [ex-xopt-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py
+[ex-xopt-sim-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI_xopt_sim.py
 [ex-optimas-libe]: https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py
 
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository is an effort to standardize the interface of the **generators** 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
 *Examples:*  
-> [Using `libEnsemble` generators in `Optimas`](https://github.com/optimas-org/optimas/pull/283)
+> [Using `libEnsemble` APOSMM generator in `Optimas`](https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py)
 >
-> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/pull/291)
+> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/blob/81cb03bf7e01fae0800347d281d57b5c0c9057f0/tests/test_xopt_generators.py)
 >
-> [Using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
+> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`](https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py)
 >
-> [Using `Optimas` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1635)
+> [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`](https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py)
 
 
 # Definitions

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository is an effort to standardize the interface of the **generators** 
 *Examples:*  
 > [Using `libEnsemble` APOSMM generator in `Optimas`](https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py)
 >
-> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/blob/81cb03bf7e01fae0800347d281d57b5c0c9057f0/tests/test_xopt_generators.py)
+> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py)
 >
 > [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`](https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py)
 >

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This repository is an effort to standardize the interface of the **generators** 
 >
 > Using `Optimas` generators in `libEnsemble`:
 > [Multi-Fidelity Ax Generator][ex-optimas-libe]
-
+>
+> Using `libEnsemble` generators in `Xopt`:
+> [APOSMM Generator][ex-aposmm-xopt]
 
 # Definitions
 
@@ -171,5 +173,5 @@ Each generator has a boolean class attribtue `returns_id`, defined in the base c
 [ex-xopt-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py
 [ex-xopt-sim-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI_xopt_sim.py
 [ex-optimas-libe]: https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py
-
+[ex-aposmm-xopt]: https://github.com/xopt-org/Xopt/blob/cfb8d704637aee31e836357cf47ac0acb82bdc71/xopt/tests/generators/external/test_aposmm.py
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This repository is an effort to standardize the interface of the **generators** 
 > [APOSMM generator][ex-aposmm-optimas]
 >
 > Using `Xopt` generators in `Optimas`:
-> [Examples][ex-xopt-optimas]
+> [Multiple Examples][ex-xopt-optimas]
 >
 > Using `Xopt` generators in `libEnsemble`:
-> [ExpectedImprovementGenerator][ex-xopt-libe] [(with Xopt-style simulation)][ex-xopt-sim-libe]
+> [ExpectedImprovement][ex-xopt-libe] - [(with Xopt-style sim)][ex-xopt-sim-libe]
 >
 > Using `Optimas` generators in `libEnsemble`:
 > [Multi-Fidelity Ax Generator][ex-optimas-libe]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This repository is an effort to standardize the interface of the **generators** 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
 *Examples:*  
-> [Using `libEnsemble` APOSMM generator in `Optimas`](https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py)
+
+> [Using `libEnsemble` APOSMM generator in `Optimas`][ex-aposmm-optimas]
 >
-> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py)
+> [Using `Xopt` generators in `Optimas`][ex-xopt-optimas]
 >
-> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`](https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py)
+> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe]
 >
-> [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`](https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py)
+> [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`][ex-optimas-libe]
 
 
 # Definitions
@@ -159,3 +160,11 @@ Each generator has a boolean class attribtue `returns_id`, defined in the base c
 - `returns_id: bool = False`
 
   Indicates whether this is an `_id` producing generator.
+
+
+[ex-aposmm-optimas]: https://github.com/optimas-org/optimas/blob/e616244012ca56972c42f0643cac5f51680d928c/tests/test_libEgen_aposmm.py
+[ex-xopt-optimas]: https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py
+[ex-xopt-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py
+[ex-optimas-libe]: https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py
+
+

--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ This repository is an effort to standardize the interface of the **generators** 
 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
-*Examples:*  
-
-> [Using `libEnsemble` APOSMM generator in `Optimas`][ex-aposmm-optimas]
+*Examples:*
+> Using `libEnsemble` generators in `Optimas`:
+> [APOSMM generator][ex-aposmm-optimas]
 >
-> [Using `Xopt` generators in `Optimas`][ex-xopt-optimas]
+> Using `Xopt` generators in `Optimas`:
+> [Examples][ex-xopt-optimas]
 >
-> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe] [(with xopt-style sim)](ex-xopt-sim-libe)
+> Using `Xopt` generators in `libEnsemble`:
+> [ExpectedImprovementGenerator][ex-xopt-libe] [(with Xopt-style simulation)][ex-xopt-sim-libe]
 >
-> [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`][ex-optimas-libe]
+> Using `Optimas` generators in `libEnsemble`:
+> [Multi-Fidelity Ax Generator][ex-optimas-libe]
 
 
 # Definitions

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ This repository is an effort to standardize the interface of the **generators** 
 
 *Examples:*
 > Using `libEnsemble` generators in `Optimas`:
-> APOSMM [NLopt][ex-aposmm-nlopt-optimas] - [IBCDFO][ex-aposmm-ibcdfo-optimas]
+> APOSMM [NLopt](https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_nlopt/run_example.py) - [IBCDFO](https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_ibcdfo/run_example.py)
 >
 > Using `Xopt` generators in `Optimas`:
-> [Multiple Examples][ex-xopt-optimas]
+> [Multiple Examples](https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py)
 >
 > Using `Xopt` generators in `libEnsemble`:
-> [ExpectedImprovement][ex-xopt-libe] - [(with Xopt-style sim)][ex-xopt-sim-libe]
+> [ExpectedImprovement](https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py) - [(with Xopt-style sim)](https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI_xopt_sim.py)
 >
 > Using `Optimas` generators in `libEnsemble`:
-> [Multi-Fidelity Ax Generator][ex-optimas-libe]
+> [Multi-Fidelity Ax Generator](https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py)
 >
 > Using `libEnsemble` generators in `Xopt`:
-> [APOSMM Generator][ex-aposmm-xopt]
+> [APOSMM Generator](https://github.com/xopt-org/Xopt/blob/cfb8d704637aee31e836357cf47ac0acb82bdc71/xopt/tests/generators/external/test_aposmm.py)
 
 # Definitions
 
@@ -54,11 +54,3 @@ The Python abstract classes that define the standard can be installed with:
 ```
 pip install gest-api
 ```
-
-[ex-aposmm-nlopt-optimas]: https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_nlopt/run_example.py
-[ex-aposmm-ibcdfo-optimas]: https://github.com/optimas-org/optimas/blob/f7f5e656f4b98e64a0c2849b6f73aabd49af7682/examples/libe_aposmm_ibcdfo/run_example.py
-[ex-xopt-optimas]: https://github.com/optimas-org/optimas/blob/f49bd63d329a8aca2a3444a6a93dbda548f71cfa/tests/test_xopt_generators.py
-[ex-xopt-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI.py
-[ex-xopt-sim-libe]: https://github.com/Libensemble/libensemble/blob/589d8fb8b0019469ad6a2784e6bcd5e2c2cac8ee/libensemble/tests/regression_tests/test_xopt_EI_xopt_sim.py
-[ex-optimas-libe]: https://github.com/Libensemble/libensemble/blob/e7fef19c19343c5eceaa4353985aa963ebada46c/libensemble/tests/regression_tests/test_optimas_ax_mf.py
-[ex-aposmm-xopt]: https://github.com/xopt-org/Xopt/blob/cfb8d704637aee31e836357cf47ac0acb82bdc71/xopt/tests/generators/external/test_aposmm.py

--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ This repository is an effort to standardize the interface of the **generators** 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
 *Examples:*  
-> [using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)  
-> [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/151)
+> [using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)
+> [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/291)
+
+> [using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
+> [using `Optimas` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1635)
+
 
 # Definitions
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository is an effort to standardize the interface of the **generators** 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
 *Examples:*  
-> [using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)
+> [Using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)
 >
-> [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/291)
+> [Using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/291)
 >
-> [using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
+> [Using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
 >
-> [using `Optimas` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1635)
+> [Using `Optimas` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1635)
 
 
 # Definitions

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This repository is an effort to standardize the interface of the **generators** 
 **The objective of this effort is for these different libraries to be able to use each other's generators with little effort.**
 
 *Examples:*  
-> [Using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)
+> [Using `libEnsemble` generators in `Optimas`](https://github.com/optimas-org/optimas/pull/283)
 >
-> [Using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/291)
+> [Using `Xopt` generators in `Optimas`](https://github.com/optimas-org/optimas/pull/291)
 >
 > [Using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
 >

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ This repository is an effort to standardize the interface of the **generators** 
 
 *Examples:*  
 > [using `libEnsemble` generators in `optimas`](https://github.com/optimas-org/optimas/pull/283)
+>
 > [using `Xopt` generators in `optimas`](https://github.com/optimas-org/optimas/pull/291)
-
+>
 > [using `Xopt` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1620)
+>
 > [using `Optimas` generators in `libEnsemble`](https://github.com/Libensemble/libensemble/pull/1635)
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is an effort to standardize the interface of the **generators** 
 >
 > [Using `Xopt` generators in `Optimas`][ex-xopt-optimas]
 >
-> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe] [with xopt-style sim](ex-xopt-sim-libe)
+> [Using `Xopt` ExpectedImprovementGenerator in `libEnsemble`][ex-xopt-libe] [(with xopt-style sim)](ex-xopt-sim-libe)
 >
 > [Using `Optimas` Multi-Fidelity Ax Generator in `libEnsemble`][ex-optimas-libe]
 


### PR DESCRIPTION
The example should be a currently working example.

I have added links to files in selected commits for APOSMM in Optimas and xopt in Optimas PRs. 
And the xopt/Optimas in libEnsemble PRs. 

When we have updated main branches of each code, we could update these to main branch or docs examples.

We should also evaluate the Generator examples, as these point to specific lines of code, which presumably may change when branches are pulled in? Perhaps these should be added as documentation links when ready, or initially hold examples in this repo?

- [x] Example gens in libE/Optimas examples
- [x] libEnsemble/Optimas gens in xopt examples
- [x] Look at generator examples under Definitions

Squash this.

