### PR TITLE
Move information from the README into docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository is an effort to standardize the interface of the **generators** 
 
   *Note:* The generator does **not** orchestrate the overall optimization (e.g. dispatch evaluations, etc.). As such, it is distinct from `libEnsemble`'s `gen_f` function, and is not itself "workflow" software.
 
-  *Examples:
+  *Examples:*
     - `Xopt`: [here](https://github.com/ChristopherMayes/Xopt/blob/main/xopt/generators/sequential/neldermead.py#L64) is the generator for the Nelder-Mead method. All Xopt generators implement the methods `generate` (i.e. make recommendations) and `add_data` (i.e. receive data).
     - `optimas`: [here](https://github.com/optimas-org/optimas/blob/main/optimas/generators/base.py#L27) is the base class for all generators. It implements the methods `suggest` (i.e. make recommendations) and `ingest` (i.e. receive data).
 
@@ -27,127 +27,16 @@ This repository is an effort to standardize the interface of the **generators** 
 
   A `VOCS` is an object that specifies the names and types of components of the optimization problem that will be used by the generator. Each generator will validate that it can handle the specified set of variables, objectives, constraints, etc.
 
+# Documentation
 
-# Standardization
+For complete API documentation, examples, and detailed specifications, see the official documentation:
 
-## VOCS
-VOCs objects specify the following fields:
+**https://generator-standard.readthedocs.io**
 
-Inputs:
-  - `variables`: defines the names and types of input parameters that will be passed to an objective function in order to solve the optimization problem.
-  - `constants` (optional): defines the names and values of constant values that will be passed alongside `variables` to the objective function.
+# Installation
 
-Outputs:
-  - `objectives`: defines the names and types of function outputs that will be optimized or explored.
-  - `constraints` (optional): defines the names and types of function outputs that will used as constraints that need to be satisfied for a valid solution to the optimization problem.
-  - `observables` (optional): defines the names of any other function outputs that should be passed to the generator (alongside the `objectives` and `constraints`).
+The Python abstract classes that define the standard can be installed with:
 
-Example:
-
-  ```python
-
-  from gest_api.vocs import VOCS
-
-  >>> VOCS(
-    variables = {"x1":[0, 1], "x2":[0, 5]},
-    objectives = {"f1":"MAXIMIZE"},
-    constants = {"alpha": 0.55},
-    constraints = {"c1":["LESS_THAN", 0]},
-    observables = {"o1"}
-  )
-  ```
-
-**TODO:** See the docs for the complete API and more examples.
-
-## Generators
-
-Each generator will be a Python class that defines the following methods:
-
-- **Constructor:**
-  `__init__(self, vocs: VOCS, *args, **kwargs)`:
-
-  The mandatory `VOCS` defines the input and output names used inside the generator.
-
-  The constructor also accomodates variable positional and keyword arguments so each generator can be customized.
-
-  Examples:
-
-  ```python
-  >>> generator = NelderMead(VOCS(variables={"x": [-5.0, 5.0], "y": [-3.0, 2.0]}, objectives={"f": "MAXIMIZE"}), adaptive=False)
-  ```
-
-- `_validate_vocs(self, vocs) -> None`:
-
-  Validates the `VOCS` passed to the generator. Raises ``ValueError`` if the VOCS passed to the generator duing construction is invalid.
-
-  Examples:
-
-  ```python
-  >>> generator = NelderMead(
-    VOCS(variables={"x": [-5.0, 5.0], "y": [-3.0, 2.0]}, objectives={"f": "MAXIMIZE"}, constraints={"c":["LESS_THAN", 0.0]})
-  )
-  ValueError("NelderMead generator cannot accept constraints")
-  ```
-
-- `suggest(num_points: int | None = None) -> list[dict]`:
-
-  Returns a list of points in the input space, to be evaluated next. Each element of the list is a separate point.
-  Keys of the dictionary include the name of each input variable specified in VOCS (variables+constants).
-  Values of the dictionaries are **scalars** unless the variable was declared with an array `dtype` attribute.
-
-  When `num_points` is passed, the generator should return exactly that number of points or raise a `ValueError`.
-
-  When `num_points` is not passed, the generator decides how many points to return.
-  In this case, different generators will return different number of points. For instance, the simplex would return 1 or 3 points. A genetic algorithm could return the whole population. Batched Bayesian optimization would return the batch size (i.e., number of points that can be processed in parallel), which would be specified in the constructor.
-
-  In addition, some generators can assign a unique identifier to each generated point (indicated by the `returns_id` class attribute). If implemented, this identifier should appear in the dictionary under the key "_id". When a generator produces an identifier, it must be included in the corresponding dictionary passed back to that generator in `ingest` (under the same key: `"_id"`).
-
-  Examples:
-
-  ```python
-
-  >>> generator.suggest(2)
-  [{"x": 1.2, "y": 0.8}, {"x": -0.2, "y": 0.4}]
-
-  >>> generator.suggest(100)  # too many points
-  ValueError
-
-  >>> generator.suggest()
-  [{"x": 1.2, "y": 0.8}, {"x": -0.2, "y": 0.4}, {"x": 4.3, "y": -0.1}]
-
-  ```
-
-- `ingest(points: list[dict])`:
-
-  Feeds data (past evaluations) to the generator. Each element of the list is a separate point. Keys of the dictionary must include each named field specified in the `VOCS` provided
-  to the generator on instantiation.
-
-  Example:
-
-  ```python
-  >>> point = generator.suggest(1)
-  >>> point
-  [{"x": 1, "y": 1}]
-  >>> point["f"] = objective(point)
-  >>> point
-  [{"x": 1, "y": 1, "f": 2}]
-  >>> generator.ingest(point)
-  ```
-
-  Any points provided to the generator via `ingest` that were not created by the current generator instance should omit the `_id` field. If points are given to `ingest` with an `_id` value that is not known internally, a `ValueError` error should be raised.
-
-- `finalize()`:
-
-  **Optional**. Performs any work required to close down the generator. Some generators may need to close down background processes, files, databases, or asynchronous components. After finalize is called, the generator’s data is guaranteed to be up to date, including results from any outstanding processes, threads, or asynchronous tasks.
-
-  Example:
-
-  ```python
-  >>> generator.finalize()
-  ```
-
-Each generator has a boolean class attribtue `returns_id`, defined in the base class as:
-
-- `returns_id: bool = False`
-
-  Indicates whether this is an `_id` producing generator.
+```
+pip install gest-api
+```

--- a/docs/generator.rst
+++ b/docs/generator.rst
@@ -2,9 +2,7 @@
 Generator API
 =============
 
-**Class Attributes:**
-
-- ``returns_id`` (bool): Indicates whether this generator returns IDs with the suggested points. Default is ``False``. Subclasses should override this if they return IDs.
+Each generator is a Python class that defines the following methods and attributes.
 
 .. autoclass:: gest_api.generator.Generator
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,27 @@
 
-======================
-README / Specification
-======================
+=========================
+Generator Standard (GeST)
+=========================
 
 .. include:: ../README.md
     :parser: myst_parser.sphinx_
     :start-after: # Overview
-    :end-before: # Standardization
+    :end-before: # Documentation
 
+Specification of the standard
+-----------------------------
+
+In order to conform to the standard, a given optimization library (e.g. `Xopt`, `optimas`, `libEnsemble`)
+must define the classes documented below, and their corresponding methods:
 
 .. toctree::
     :maxdepth: 2
 
     generator
     vocs
+
+This is best done by subclassing the abstract classes defined in the Python package `gest-api`, which can be installed with:
+
+.. code-block:: bash
+
+    pip install gest-api

--- a/docs/vocs.rst
+++ b/docs/vocs.rst
@@ -14,7 +14,6 @@ VOCS API
 
 
 .. autoclass:: gest_api.vocs.VOCS
-   :no-members:
 
 
 .. tab-set::

--- a/docs/vocs.rst
+++ b/docs/vocs.rst
@@ -113,11 +113,7 @@ VOCS API
             ...
             vocs = VOCS(observables={"temp": "float", "temp2": "int"})
 
-
-The :class:`~gest_api.vocs.VOCS` class defines all inputs and outputs
-of an optimization problem.
-
-Each section below links to the detailed structure for that parameter type.
+Each section below links to the detailed structure for the parameters.
 
 .. toctree::
    :maxdepth: 1

--- a/gest_api/generator.py
+++ b/gest_api/generator.py
@@ -4,8 +4,11 @@ from .vocs import VOCS
 
 class Generator(ABC):
     """
-    Tentative suggest/ingest generator interface
+    A generator is an object that recommends points to be evaluated in an optimization, using the `suggest` method.
+    It can also receive data (evaluations from past or ongoing optimization), using the `ingest` method, which helps
+    it make more informed recommendations.
 
+    *Example:*
     .. code-block:: python
 
         class MyGenerator(Generator):

--- a/gest_api/generator.py
+++ b/gest_api/generator.py
@@ -29,6 +29,12 @@ class Generator(ABC):
     """
 
     returns_id: bool = False
+    """
+    Indicates whether this generator returns IDs with the suggested points. Default is ``False``.
+    Subclasses should override this if they return IDs. When a generator produces an identifier,
+    it must be included in the corresponding dictionary passed back to that generator in ``ingest``
+    (under the same key: ``"_id"``).
+    """
 
     @abstractmethod
     def __init__(self, vocs: VOCS, *args, **kwargs):
@@ -36,9 +42,21 @@ class Generator(ABC):
         Initialize the Generator object on the user-side. Constants, class-attributes,
         and preparation goes here.
 
+        The mandatory `VOCS` defines the input and output names used inside the generator.
+        The constructor also accommodates variable positional and keyword arguments so each
+        generator can be customized.
+
+        **Parameters:**
+            - ``vocs`` (VOCS): The mandatory VOCS object that defines the input and output names.
+            - ``*args``: Variable positional arguments for generator-specific customization.
+            - ``**kwargs``: Variable keyword arguments for generator-specific customization.
+
         .. code-block:: python
 
-            >>> my_generator = MyGenerator(vocs, my_keyword=10)
+            >>> generator = NelderMead(
+            ...     VOCS(variables={"x": [-5.0, 5.0], "y": [-3.0, 2.0]}, objectives={"f": "MAXIMIZE"}),
+            ...     adaptive=False
+            ... )
         """
         self._validate_vocs(vocs)
 
@@ -47,7 +65,26 @@ class Generator(ABC):
         """
         Validate if the vocs object is compatible with the current generator. Should
         raise a ValueError if the vocs object is not compatible with the generator
-        object
+        object.
+
+        This method is called automatically during initialization.
+
+        **Parameters:**
+            - ``vocs`` (VOCS): The VOCS object to validate.
+
+        **Raises:**
+            - ``ValueError``: If the VOCS is not compatible with the generator.
+
+        .. code-block:: python
+
+            >>> generator = NelderMead(
+            ...     VOCS(
+            ...         variables={"x": [-5.0, 5.0], "y": [-3.0, 2.0]},
+            ...         objectives={"f": "MAXIMIZE"},
+            ...         constraints={"c": ["LESS_THAN", 0.0]}
+            ...     )
+            ... )
+            ValueError("NelderMead generator cannot accept constraints")
         """
 
     @abstractmethod
@@ -55,28 +92,91 @@ class Generator(ABC):
         """
         Request the next set of points to evaluate.
 
+        Returns a list of points in the input space, to be evaluated next. Each element of the list
+        is a separate point. Keys of the dictionary include the name of each input variable specified
+        in VOCS (variables + constants). Values of the dictionaries are **scalars** unless the variable
+        was declared with an array ``dtype`` attribute.
+
+        **Parameters:**
+            - ``num_points`` (int | None): Optional number of points to generate. When not provided,
+              the generator decides how many points to return.
+
+        **Returns:**
+            - ``list[dict]``: A list of dictionaries, where each dictionary represents a point to
+              evaluate. Each dictionary contains keys for all variables and constants from the VOCS,
+              and optionally an ``"_id"`` key if the generator supports IDs.
+
+        **Raises:**
+            - ``ValueError``: If ``num_points`` is specified but the generator cannot produce that
+              exact number of points.
+
+        **Notes:**
+            - When ``num_points`` is passed, the generator should return exactly that number of points
+              or raise a ``ValueError``.
+            - When ``num_points`` is not passed, the generator decides how many points to return.
+              Different generators will return different numbers of points. For instance, the simplex
+              would return 1 or 3 points. A genetic algorithm could return the whole population.
+              Batched Bayesian optimization would return the batch size (i.e., number of points that
+              can be processed in parallel), which would be specified in the constructor.
+            - Some generators can assign a unique identifier to each generated point (indicated by the
+              ``returns_id`` class attribute). If implemented, this identifier should appear in the
+              dictionary under the key ``"_id"``.
+
         .. code-block:: python
 
-            >>> points = my_generator.suggest(3)
+            >>> points = generator.suggest(2)
             >>> print(points)
-            [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 3, "y": 3}]
+            [{"x": 1.2, "y": 0.8}, {"x": -0.2, "y": 0.4}]
+
+            >>> points = generator.suggest()  # Generator decides
+            >>> print(points)
+            [{"x": 1.2, "y": 0.8}, {"x": -0.2, "y": 0.4}, {"x": 4.3, "y": -0.1}]
         """
 
     def ingest(self, results: list[dict]) -> None:
         """
         Send the results of evaluations to the generator.
 
+        Feeds data (past evaluations) to the generator. Each element of the list is a separate point.
+        Keys of the dictionary must include each named field specified in the VOCS provided to the
+        generator on instantiation (variables, constants, objectives, constraints, and observables).
+
+        **Parameters:**
+            - ``results`` (list[dict]): A list of dictionaries, where each dictionary represents an
+              evaluated point. Each dictionary must contain keys for all variables, constants,
+              objectives, constraints, and observables from the VOCS.
+
+        **Raises:**
+            - ``ValueError``: If points are given to ``ingest`` with an ``_id`` value that is not known
+              internally (for generators that support IDs).
+
+        **Notes:**
+            - Any points provided to the generator via ``ingest`` that were not created by the current
+              generator instance should omit the ``_id`` field.
+            - If points are given to ``ingest`` with an ``_id`` value that is not known internally,
+              a ``ValueError`` error should be raised.
+
         .. code-block:: python
 
-            >>> results = [{"x": 0.5, "y": 1.5, "f": 1}, {"x": 2, "y": 3, "f": 4}]
-            >>> my_generator.ingest(results)
+            >>> point = generator.suggest(1)
+            >>> point
+            [{"x": 1, "y": 1}]
+            >>> point[0]["f"] = objective(point[0])
+            >>> point
+            [{"x": 1, "y": 1, "f": 2}]
+            >>> generator.ingest(point)
         """
 
     def finalize(self) -> None:
         """
         Perform any work required to close down the generator.
 
+        **Optional.** Performs any work required to close down the generator. Some generators may need
+        to close down background processes, files, databases, or asynchronous components. After
+        finalize is called, the generator's data is guaranteed to be up to date, including results
+        from any outstanding processes, threads, or asynchronous tasks.
+
         .. code-block:: python
 
-            >>> my_generator.finalize()
+            >>> generator.finalize()
         """

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -279,6 +279,31 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     """
     Variables, Objectives, Constraints, and other Settings (VOCS) data structure
     to describe optimization problems.
+
+    VOCS objects specify the following fields:
+
+    **Inputs:**
+        - ``variables``: defines the names and types of input parameters that will be passed to an objective function in order to solve the optimization problem.
+        - ``constants`` (optional): defines the names and values of constant values that will be passed alongside ``variables`` to the objective function.
+
+    **Outputs:**
+        - ``objectives``: defines the names and types of function outputs that will be optimized or explored.
+        - ``constraints`` (optional): defines the names and types of function outputs that will be used as constraints that need to be satisfied for a valid solution to the optimization problem.
+        - ``observables`` (optional): defines the names of any other function outputs that should be passed to the generator (alongside the ``objectives`` and ``constraints``).
+
+    **Example:**
+
+    .. code-block:: python
+
+        from gest_api.vocs import VOCS
+
+        vocs = VOCS(
+            variables={"x1": [0, 1], "x2": [0, 5]},
+            objectives={"f1": "MAXIMIZE"},
+            constants={"alpha": 0.55},
+            constraints={"c1": ["LESS_THAN", 0]},
+            observables={"o1"}
+        )
     """
     variables: VariableDict = Field(
         description="variable names with bounds or discrete sets"


### PR DESCRIPTION
The README had information that was redundant/duplicated with the Sphinx documentation. 

This PR consolidates all the information in the Sphinx documentation. The README now mostly points to the Sphinx documentation.