### PR TITLE
Update vocs.py

### DIFF
--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 from gest_api.vocs import (
+    BaseVariable,
     ContinuousVariable,
     DiscreteVariable,
     VOCS,
@@ -421,6 +422,30 @@ def test_constant_dict_construction():
 def test_bounds_property():
     vocs = VOCS(variables={"x": [0, 1], "y": [2, 4]})
     assert vocs.bounds == [[0, 1], [2, 4]]
+
+
+def test_bounds_property_empty_variables():
+    vocs = VOCS(variables={})
+    assert vocs.bounds == []
+
+
+def test_bounds_property_with_numeric_discrete_variable():
+    vocs = VOCS(variables={"x": [0, 1], "d": {5, 1, 3}})
+    assert vocs.bounds == [[0, 1], [1.0, 5.0]]
+
+
+def test_bounds_property_non_numeric_discrete_variable_raises():
+    vocs = VOCS(variables={"x": {"a", "b"}})
+    with pytest.raises(ValueError, match="cannot be converted to bounds"):
+        _ = vocs.bounds
+
+
+def test_bounds_property_ignores_non_continuous_non_discrete_base_variable():
+    class DummyVariable(BaseVariable):
+        pass
+
+    vocs = VOCS(variables={"x": [0, 1], "dummy": DummyVariable()})
+    assert vocs.bounds == [[0, 1]]
 
 
 def test_variable_names_property():

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -173,14 +173,11 @@ class ConstraintDict(ValidatedDict):
 class BaseObjective(BaseField):
     pass
 
-
 class MinimizeObjective(BaseObjective):
     pass
 
-
 class MaximizeObjective(BaseObjective):
     pass
-
 
 class ExploreObjective(BaseObjective):
     pass
@@ -370,7 +367,21 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [v.domain for _, v in self.variables.items()]
+        bounds: list = []
+        for _, v in self.variables.items():
+            if isinstance(v, ContinuousVariable):
+                bounds.append(v.domain)
+            elif isinstance(v, DiscreteVariable):
+                # check to make sure discrete variables are numeric and can be converted to bounds
+                try:
+                    numeric_values = sorted(float(val) for val in v.values)
+                    bounds.append([numeric_values[0], numeric_values[-1]])
+                except ValueError:
+                    raise ValueError(
+                        f"Discrete variable with non-numeric values cannot be converted to bounds: {v.values}"
+                    )
+
+        return bounds
 
     @property
     def variable_names(self) -> list[str]:

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -173,11 +173,14 @@ class ConstraintDict(ValidatedDict):
 class BaseObjective(BaseField):
     pass
 
+
 class MinimizeObjective(BaseObjective):
     pass
 
+
 class MaximizeObjective(BaseObjective):
     pass
+
 
 class ExploreObjective(BaseObjective):
     pass


### PR DESCRIPTION
This pull request introduces improvements to how variable bounds are computed in the `gest_api/vocs.py` file, making the bounds property more robust for both continuous and discrete variables.

**Enhancements to variable bounds calculation:**

* Updated the `bounds` property to handle both `ContinuousVariable` and `DiscreteVariable` types. For discrete variables, it now attempts to convert values to numeric bounds and raises a clear error if non-numeric values are encountered.