### PR TITLE
add contextual variable

### DIFF
--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -421,8 +421,12 @@ def test_constant_dict_construction():
 
 
 def test_bounds_property():
-    vocs = VOCS(variables={"x": [0, 1], "y": [2, 4]})
-    assert vocs.bounds == [[0, 1], [2, 4]]
+    vocs = VOCS(variables={"x": [0, 1], "y": [2, 4], "z": "CONTEXTUAL"})
+    assert vocs.bounds == [
+        [0, 1],
+        [2, 4],
+        [-float("inf"), float("inf")],
+    ]  # Contextual variable has unbounded domain
 
 
 def test_variable_names_property():

--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 from gest_api.vocs import (
     ContinuousVariable,
     DiscreteVariable,
+    ContextualVariable,
     VOCS,
     BoundsConstraint,
     GreaterThanConstraint,
@@ -527,3 +528,17 @@ def test_n_outputs_property():
         observables=["temp"],
     )
     assert vocs.n_outputs == 5
+
+
+def test_has_contextual_variables_property():
+    vocs_with_context = VOCS(
+        variables={
+            "x": [0.0, 1.0],
+            "context": ContextualVariable(dtype="float"),
+        }
+    )
+    assert vocs_with_context.has_contextual_variables is True
+    assert vocs_with_context.bounds == [[0.0, 1.0]]
+
+    vocs_without_context = VOCS(variables={"x": [0.0, 1.0]})
+    assert vocs_without_context.has_contextual_variables is False

--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -301,11 +301,7 @@ def test_vocs_3b():
 
 def test_vocs_serialization_deserialization():
     vocs = VOCS(
-        variables={
-            "x": [0, 1],
-            "y": {"a", "b", "c"},
-            "z": "CONTEXTUAL"
-        },
+        variables={"x": [0, 1], "y": {"a", "b", "c"}, "z": "CONTEXTUAL"},
         objectives={"f1": "MINIMIZE", "f2": "MAXIMIZE", "f3": "EXPLORE"},
         constraints={
             "c": ["GREATER_THAN", 0.0],

--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -543,7 +543,6 @@ def test_has_contextual_variables_property():
         }
     )
     assert vocs_with_context.has_contextual_variables is True
-    assert vocs_with_context.bounds == [[0.0, 1.0]]
 
     vocs_without_context = VOCS(variables={"x": [0.0, 1.0]})
     assert vocs_without_context.has_contextual_variables is False

--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -546,3 +546,8 @@ def test_has_contextual_variables_property():
 
     vocs_without_context = VOCS(variables={"x": [0.0, 1.0]})
     assert vocs_without_context.has_contextual_variables is False
+
+
+def test_bad_string_variable_type():
+    with pytest.raises(ValueError, match="unrecognized string value"):
+        VOCS(variables={"x": "INVALID_TYPE"}, objectives={})

--- a/gest_api/tests/test_vocs.py
+++ b/gest_api/tests/test_vocs.py
@@ -186,12 +186,16 @@ def test_vocs_1a():
         variables={
             "x": [0, 1],  # Defaults to Continuous even if integer bounds
             "y": {"a", "b", "c"},
+            "z": "CONTEXTUAL",
         },
         objectives={"f": "MINIMIZE"},
         observables={"temp": "float", "temp_type": int, "temp_array": (float, (2, 4))},
     )
     assert isinstance(vocs.variables["x"], ContinuousVariable)
     assert isinstance(vocs.variables["y"], DiscreteVariable)
+    assert isinstance(vocs.variables["z"], ContextualVariable)
+    assert vocs.variables["x"].domain == [0, 1]
+    assert vocs.variables["z"].domain == [-float("inf"), float("inf")]
     assert isinstance(vocs.observables["temp"], Observable)
     assert vocs.observables["temp"].dtype == "float"
     assert isinstance(vocs.observables["temp_type"], Observable)
@@ -300,6 +304,7 @@ def test_vocs_serialization_deserialization():
         variables={
             "x": [0, 1],
             "y": {"a", "b", "c"},
+            "z": "CONTEXTUAL"
         },
         objectives={"f1": "MINIMIZE", "f2": "MAXIMIZE", "f3": "EXPLORE"},
         constraints={

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -388,10 +388,7 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [
-            v.domain
-            for _, v in self.variables.items()
-        ]
+        return [v.domain for _, v in self.variables.items()]
 
     @property
     def variable_names(self) -> list[str]:

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -391,7 +391,6 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
         return [
             v.domain
             for _, v in self.variables.items()
-            if isinstance(v, ContinuousVariable)
         ]
 
     @property

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -388,7 +388,7 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [v.domain for _, v in self.variables.items()]
+        return [v.domain for _, v in self.variables.items() if isinstance(v, ContinuousVariable)]
 
     @property
     def variable_names(self) -> list[str]:

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -41,8 +41,17 @@ class DiscreteVariable(BaseVariable):
     )
 
 
-class ContextualVariable(BaseVariable):
-    pass
+class ContextualVariable(ContinuousVariable):
+    """
+    A variable that is not optimized over, but rather is observed and can be conditioned on.
+
+    By default, contextual variables are unbounded. In contexts that require finite bounds,
+    bounds should be inferred from the currently available data.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("domain", [-float("inf"), float("inf")])
+        super().__init__(**kwargs)
 
 
 class ValidatedDict(dict, ABC):
@@ -88,6 +97,13 @@ class VariableDict(ValidatedDict):
             except KeyError:
                 raise ValueError(f"variable type {variable_type} is not available")
             return class_(**val)
+        elif isinstance(val, str):
+            if val.upper() == "CONTEXTUAL":
+                return ContextualVariable()
+            else:
+                raise ValueError(
+                    f"variable {name}: unrecognized string value '{val}'."
+                )
         else:
             raise ValueError(
                 f"variable {name}: input type {type(val)} not supported. "

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -40,8 +40,10 @@ class DiscreteVariable(BaseVariable):
         description="List of allowed discrete values"
     )
 
+
 class ContextualVariable(BaseVariable):
     pass
+
 
 class ValidatedDict(dict, ABC):
     def __init__(self, *args, **kwargs):
@@ -372,7 +374,11 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [v.domain for _, v in self.variables.items() if not isinstance(v, ContextualVariable)]
+        return [
+            v.domain
+            for _, v in self.variables.items()
+            if not isinstance(v, ContextualVariable)
+        ]
 
     @property
     def variable_names(self) -> list[str]:
@@ -452,7 +458,7 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     def n_outputs(self) -> int:
         """Return the total number of outputs (objectives + constraints + observables)."""
         return len(self.output_names)
-    
+
     @property
     def has_contextual_variables(self) -> bool:
         """Return True if there are any contextual variables, False otherwise."""

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -388,11 +388,7 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [
-            v.domain
-            for _, v in self.variables.items()
-            if not isinstance(v, ContextualVariable)
-        ]
+        return [v.domain for _, v in self.variables.items()]
 
     @property
     def variable_names(self) -> list[str]:

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -388,7 +388,11 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [v.domain for _, v in self.variables.items() if isinstance(v, ContinuousVariable)]
+        return [
+            v.domain
+            for _, v in self.variables.items()
+            if isinstance(v, ContinuousVariable)
+        ]
 
     @property
     def variable_names(self) -> list[str]:

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -40,6 +40,8 @@ class DiscreteVariable(BaseVariable):
         description="List of allowed discrete values"
     )
 
+class ContextualVariable(BaseVariable):
+    pass
 
 class ValidatedDict(dict, ABC):
     def __init__(self, *args, **kwargs):
@@ -370,7 +372,7 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     @property
     def bounds(self) -> list:
         """Return the domain bounds for all variables as a list of [lower, upper] pairs."""
-        return [v.domain for _, v in self.variables.items()]
+        return [v.domain for _, v in self.variables.items() if not isinstance(v, ContextualVariable)]
 
     @property
     def variable_names(self) -> list[str]:
@@ -450,3 +452,8 @@ class VOCS(BaseModel, validate_assignment=True, arbitrary_types_allowed=True):
     def n_outputs(self) -> int:
         """Return the total number of outputs (objectives + constraints + observables)."""
         return len(self.output_names)
+    
+    @property
+    def has_contextual_variables(self) -> bool:
+        """Return True if there are any contextual variables, False otherwise."""
+        return any(isinstance(v, ContextualVariable) for v in self.variables.values())

--- a/gest_api/vocs.py
+++ b/gest_api/vocs.py
@@ -101,9 +101,7 @@ class VariableDict(ValidatedDict):
             if val.upper() == "CONTEXTUAL":
                 return ContextualVariable()
             else:
-                raise ValueError(
-                    f"variable {name}: unrecognized string value '{val}'."
-                )
+                raise ValueError(f"variable {name}: unrecognized string value '{val}'.")
         else:
             raise ValueError(
                 f"variable {name}: input type {type(val)} not supported. "


### PR DESCRIPTION
This pull request introduces support for contextual variables in the `VOCS` class and updates related logic to handle them appropriately. Contextual variables are those that effect objectives/constraints of interest, but are measured and cannot be controlled directly. As such they are listed as variables. By default they have (-inf, inf) bounds, but these bounds can be overwritten if finite bounds are required (to be implemented by the package).

**Support for Contextual Variables:**

* Added a new `ContextualVariable` class as a subclass of `ContinuousVariable` in `gest_api/vocs.py` to represent contextual variables.
* Added a `has_contextual_variables` property to the `VOCS` class to indicate if any contextual variables are present.

**Testing:**

* Added a new test `test_has_contextual_variables_property` in `gest_api/tests/test_vocs.py` to verify the behavior of the `has_contextual_variables` property and ensure contextual variables are excluded from bounds.
* Imported `ContextualVariable` in the test file to support the new tests.